### PR TITLE
Refactor progress bar timer handling

### DIFF
--- a/application/lib/ui/progressLine.dart
+++ b/application/lib/ui/progressLine.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
@@ -51,13 +53,13 @@ class ProgressLine extends HookWidget {
       showNewDots.value = false;
       displayedPage.value = prevPage ?? currentPage;
 
-      Future.delayed(const Duration(milliseconds: 200), () {
+      final timer = Timer(const Duration(milliseconds: 200), () {
         showNewDots.value = true;
         displayedPage.value = currentPage;
         controller.forward(from: 0);
       });
 
-      return null;
+      return timer.cancel;
     }, [currentPage]);
 
     return SizedBox(


### PR DESCRIPTION
## Summary
- replace Future.delayed with cancellable Timer in progress line hook
- ensure timer is cancelled via cleanup in useEffect

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68904cf8afd4832294a3bf8d18d3479b