### PR TITLE
chore: add const constructors for constant widgets

### DIFF
--- a/application/lib/LoginSignup/login.dart
+++ b/application/lib/LoginSignup/login.dart
@@ -122,7 +122,7 @@ class LoginPage extends HookConsumerWidget {
                       Text(
                         title,
                         textAlign: TextAlign.start,
-                        style: TextStyle(
+                        style: const TextStyle(
                           fontSize: AppTheme.headlineFont * textScale,
                           fontFamily: 'Poppins-ExtraBold',
                           color: AppTheme.navyBlue,
@@ -135,7 +135,7 @@ class LoginPage extends HookConsumerWidget {
                           child: Text(
                             description!,
                             textAlign: TextAlign.justify,
-                            style: TextStyle(
+                            style: const TextStyle(
                               fontSize: AppTheme.bodyFont * textScale,
                               fontFamily: 'Poppins-medium',
                               color: Colors.white,
@@ -176,7 +176,7 @@ class LoginPage extends HookConsumerWidget {
                           width: 60.w,
                           child: Text(
                             isPasswordVisible.value ? 'HIDE' : 'SHOW',
-                            style: TextStyle(
+                            style: const TextStyle(
                               fontFamily: 'Montserrat',
                               color: AppTheme.black,
                               fontSize: 10.sp,
@@ -212,9 +212,9 @@ class LoginPage extends HookConsumerWidget {
                                 endIndent: 8.w,
                               ),
                             ),
-                            Text(
+                            const Text(
                               'OR',
-                              style: TextStyle(
+                              style: const TextStyle(
                                 color: Colors.grey,
                                 fontSize: 16,
                                 fontWeight: FontWeight.bold,

--- a/application/lib/services/otpDialog.dart
+++ b/application/lib/services/otpDialog.dart
@@ -57,7 +57,7 @@ class OtpDialog extends HookWidget {
             Text(
               'Verify your account',
               textAlign: TextAlign.center,
-              style: TextStyle(
+              style: const TextStyle(
                 fontFamily: 'Montserrat',
                 fontSize: 18.sp * textScale,
                 fontWeight: FontWeight.w800,
@@ -72,7 +72,7 @@ class OtpDialog extends HookWidget {
             RichText(
               textAlign: TextAlign.center,
               text: TextSpan(
-                style: TextStyle(
+                style: const TextStyle(
                   fontFamily: 'Montserrat',
                   fontSize: 12.sp * textScale,
                   color: AppTheme.gray,
@@ -155,10 +155,10 @@ class OtpDialog extends HookWidget {
                 Navigator.of(context).pop();
                 await onBiometric();
               },
-              icon: Icon(Icons.fingerprint, color: AppTheme.navyBlue),
-              label: Text(
+              icon: const Icon(Icons.fingerprint, color: AppTheme.navyBlue),
+              label: const Text(
                 'Biometric Verification',
-                style: TextStyle(
+                style: const TextStyle(
                   fontFamily: 'Montserrat',
                   fontWeight: FontWeight.w600,
                   color: AppTheme.navyBlue,


### PR DESCRIPTION
## Summary
- mark constant login separator text as `const`
- use const constructors for biometric button in OTP dialog

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68904cfa09648322ad34791aaa144a78