### PR TITLE
feat(auth): handle token refresh via shared Dio

### DIFF
--- a/lib/network/dioClient.dart
+++ b/lib/network/dioClient.dart
@@ -12,7 +12,7 @@ final dioProvider = Provider<Dio>((ref) {
     headers: {'Accept': 'application/json'},
   ));
   dio.interceptors.addAll([
-    AuthInterceptor(ref),
+    AuthInterceptor(ref, dio),
     if (Env.enableLogs) LoggerInterceptor(),
   ]);
   return dio;

--- a/lib/network/interceptors.dart
+++ b/lib/network/interceptors.dart
@@ -4,12 +4,28 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import '../global/env.dart';
 import 'tokenStore.dart';
 
-class AuthInterceptor extends Interceptor {
+/// Interceptor that automatically attaches the access token to requests and
+/// refreshes it transparently when a 401 is encountered. Uses a shared
+/// [Dio] instance with interceptors temporarily disabled while the refresh is
+/// in-flight and guards concurrent refresh attempts with a cached [Future].
+class AuthInterceptor extends QueuedInterceptor {
   final Ref ref;
-  AuthInterceptor(this.ref);
+  final Dio _dio;
+
+  /// Cached refresh call to ensure only a single refresh request executes at a
+  /// time. Subsequent calls await this future.
+  Future<TokenPair?>? _refreshFuture;
+
+  AuthInterceptor(this.ref, this._dio);
 
   @override
   void onRequest(RequestOptions options, RequestInterceptorHandler handler) {
+    // Skip auth on refresh requests.
+    if (options.extra['noAuth'] == true) {
+      handler.next(options);
+      return;
+    }
+
     final token = ref.read(tokenStoreProvider)?.accessToken;
     if (token != null && (options.headers['Authorization'] as String?) == null) {
       options.headers['Authorization'] = 'Bearer $token';
@@ -19,26 +35,52 @@ class AuthInterceptor extends Interceptor {
 
   @override
   Future onError(DioException err, ErrorInterceptorHandler handler) async {
-    // naive 401 refresh sketch (replace with your real refresh call)
     if (err.response?.statusCode == 401) {
       final refresh = ref.read(tokenStoreProvider)?.refreshToken;
       if (refresh != null) {
         try {
-          // Example: request new token
-          final dio = Dio(BaseOptions(baseUrl: Env.baseUrl));
-          final res = await dio.post('/auth/refresh', data: {'refresh_token': refresh});
-          final newAccess = res.data['access_token'] as String?;
-          if (newAccess != null) {
-            ref.read(tokenStoreProvider.notifier).save(TokenPair(newAccess, refresh));
+          _refreshFuture ??= _refreshToken(refresh);
+          final tokenPair = await _refreshFuture!;
+          if (tokenPair != null) {
+            ref.read(tokenStoreProvider.notifier).save(tokenPair);
             final request = err.requestOptions;
-            request.headers['Authorization'] = 'Bearer $newAccess';
-            final retry = await dio.fetch(request);
-            return handler.resolve(retry);
+            request.headers['Authorization'] = 'Bearer ${tokenPair.accessToken}';
+            final retryResponse = await _dio.fetch(request);
+            return handler.resolve(retryResponse);
           }
-        } catch (_) { /* fall through */ }
+        } catch (_) {
+          // fall through to clear tokens and propagate error
+        } finally {
+          _refreshFuture = null;
+        }
+        // Refresh failed
+        ref.read(tokenStoreProvider.notifier).save(null);
+        return handler.next(err);
       }
     }
     return handler.next(err);
+  }
+
+  /// Performs the refresh token call using the shared [_dio] instance but with
+  /// interceptors disabled so it doesn't trigger itself.
+  Future<TokenPair?> _refreshToken(String refresh) async {
+    try {
+      _dio.lock();
+      final res = await _dio.post(
+        '/auth/refresh',
+        data: {'refresh_token': refresh},
+        options: Options(extra: {'noAuth': true}),
+      );
+      final newAccess = res.data['access_token'] as String?;
+      if (newAccess != null) {
+        return TokenPair(newAccess, refresh);
+      }
+    } catch (_) {
+      // swallow errors; caller handles null
+    } finally {
+      _dio.unlock();
+    }
+    return null;
   }
 }
 


### PR DESCRIPTION
## Summary
- refresh tokens using shared Dio instance with interceptors disabled
- prevent concurrent refresh requests with cached future
- clear tokens and bubble 401 on refresh failure

## Testing
- `dart format lib/network/interceptors.dart lib/network/dioClient.dart` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*
- `dart test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68ac1e7eadf8832291638d670c9eef21